### PR TITLE
Terraform for function app and storage

### DIFF
--- a/infrastructure/.gitignore
+++ b/infrastructure/.gitignore
@@ -1,0 +1,34 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/infrastructure/.terraform.lock.hcl
+++ b/infrastructure/.terraform.lock.hcl
@@ -1,0 +1,20 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "2.39.0"
+  constraints = "~> 2.39.0"
+  hashes = [
+    "h1:C7Pt4vR2vvt9vRQmI7dVCvzDYugNHdU4AHuq+AhKYCE=",
+    "zh:036bbe491c2f6128597807ca15562af9b680e364e3515cba0448b2f620852381",
+    "zh:1e30206fcc2cd9880acbcbcbf5ca2be334c9a262d31a07d60f1ba20d3096601e",
+    "zh:1e5ec46490d8def13cb8c017d93ed5da1048ecb2785521e1f2618ec31c3e83dc",
+    "zh:4dad722c70510456ec540828c254f290fd02d914636747fa33e2413a72453330",
+    "zh:592ecae66830fb7b229f85a386df7e801f2c636ddd2224f84b82646646957fa8",
+    "zh:5c1f99c0748a8fdab8145b4be34bff0996473b9fb67d727c2950a40c122459c5",
+    "zh:5fbe7a78a5c5ca87cfc02ab68e2ded8a0611774af1ac4062fc6bce6b53888f4d",
+    "zh:6dcc6ccbd0b94ace6dbbfe4469de66f54f85a6a4e1042df55ac5516a56f4253f",
+    "zh:c0ed04387d3c8e1ba58171bfac69dc56090d89473ca757333208bd98204cd8e7",
+    "zh:e97374e250d003920fe743a7360cc97591815527c9b3537dba288831f98ea055",
+  ]
+}

--- a/infrastructure/terraform.tf
+++ b/infrastructure/terraform.tf
@@ -1,0 +1,65 @@
+######################################################################
+# Terraform init
+######################################################################
+
+terraform {
+  required_providers {
+    azurerm = {
+        # The "hashicorp" namespace is the new home for the HashiCorp-maintained
+        # provider plugins.
+        #
+        # source is not required for the hashicorp/* namespace as a measure of
+        # backward compatibility for commonly-used providers, but recommended for
+        # explicitness.
+        source  = "hashicorp/azurerm"
+        version = "~> 2.39.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+######################################################################
+# Resources
+######################################################################
+
+resource "azurerm_resource_group" "rg" {
+  name     = var.rgName
+  location = var.location
+
+  tags = var.tags
+}
+
+resource "azurerm_storage_account" "storage" {
+  name                     = var.storageName
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+
+  tags = var.tags
+}
+
+resource "azurerm_app_service_plan" "asp" {
+  name                = var.servicePlanName
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  kind                = "FunctionApp"
+
+  sku {
+    tier = "Dynamic"
+    size = "Y1"
+  }
+}
+
+resource "azurerm_function_app" "functionApp" {
+  name                       = var.functionAppName
+  location                   = azurerm_resource_group.rg.location
+  resource_group_name        = azurerm_resource_group.rg.name
+  app_service_plan_id        = azurerm_app_service_plan.asp.id
+  storage_account_name       = azurerm_storage_account.storage.name
+  storage_account_access_key = azurerm_storage_account.storage.primary_access_key
+}

--- a/infrastructure/terraform.tf
+++ b/infrastructure/terraform.tf
@@ -43,6 +43,8 @@ resource "azurerm_storage_account" "storage" {
   tags = var.tags
 }
 
+### Function app ###
+
 resource "azurerm_app_service_plan" "asp" {
   name                = var.servicePlanName
   location            = azurerm_resource_group.rg.location
@@ -55,6 +57,13 @@ resource "azurerm_app_service_plan" "asp" {
   }
 }
 
+resource "azurerm_application_insights" "ai" {
+  name                = var.appInsightsName
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  application_type    = "web"
+}
+
 resource "azurerm_function_app" "functionApp" {
   name                       = var.functionAppName
   location                   = azurerm_resource_group.rg.location
@@ -63,6 +72,10 @@ resource "azurerm_function_app" "functionApp" {
   storage_account_name       = azurerm_storage_account.storage.name
   storage_account_access_key = azurerm_storage_account.storage.primary_access_key
   version                    = "~3"
+
+  app_settings = {
+    "APPINSIGHTS_INSTRUMENTATIONKEY" = azurerm_application_insights.ai.instrumentation_key
+  }
 
   connection_string {
     name = "trainingafstorage_STORAGE"

--- a/infrastructure/terraform.tf
+++ b/infrastructure/terraform.tf
@@ -64,6 +64,12 @@ resource "azurerm_function_app" "functionApp" {
   storage_account_access_key = azurerm_storage_account.storage.primary_access_key
   version                    = "~3"
 
+  connection_string {
+    name = "trainingafstorage_STORAGE"
+    type = "Custom"
+    value = azurerm_storage_account.storage.primary_connection_string
+  }
+
   site_config {
     http2_enabled = true
   }

--- a/infrastructure/terraform.tf
+++ b/infrastructure/terraform.tf
@@ -62,4 +62,5 @@ resource "azurerm_function_app" "functionApp" {
   app_service_plan_id        = azurerm_app_service_plan.asp.id
   storage_account_name       = azurerm_storage_account.storage.name
   storage_account_access_key = azurerm_storage_account.storage.primary_access_key
+  version                    = "~3"
 }

--- a/infrastructure/terraform.tf
+++ b/infrastructure/terraform.tf
@@ -63,4 +63,8 @@ resource "azurerm_function_app" "functionApp" {
   storage_account_name       = azurerm_storage_account.storage.name
   storage_account_access_key = azurerm_storage_account.storage.primary_access_key
   version                    = "~3"
+
+  site_config {
+    http2_enabled = true
+  }
 }

--- a/infrastructure/terraform.tfvars
+++ b/infrastructure/terraform.tfvars
@@ -1,0 +1,7 @@
+rgName = "training-azure-fuctions-tweeter-rg"
+
+storageName = "trainingafstorage"
+
+servicePlanName = "functionServicePlan"
+appInsightsName = "applicationInsights"
+functionAppName = "twitterTrainingFunctionPW"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -36,6 +36,11 @@ variable "servicePlanName" {
   default = "functionServicePlan"
 }
 
+variable "appInsightsName" {
+  type = string
+  default = "applicationInsights"
+}
+
 variable "functionAppName" {
   type = string
   default = "twitterTrainingFunctionPW"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -1,0 +1,42 @@
+######################################################################
+# Variables
+######################################################################
+
+variable "tags" {
+  type = object({
+    environment = string
+  })
+  default = {
+    environment = "Terraform Training"
+  }
+}
+
+variable "location" {
+  type = string
+  default = "West Europe"
+  description = "Location in which to create resources"
+}
+
+variable "rgName" {
+  type = string
+  default = "training-azure-fuctions-tweeter-rg"
+  description = "Name of resource group"
+}
+
+variable "storageName" {
+  type = string
+  default = "trainingafstorage"
+  description = "Name of storage account"
+}
+
+# Function App
+
+variable "servicePlanName" {
+  type = string
+  default = "functionServicePlan"
+}
+
+variable "functionAppName" {
+  type = string
+  default = "twitterTrainingFunctionPW"
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -19,29 +19,24 @@ variable "location" {
 
 variable "rgName" {
   type = string
-  default = "training-azure-fuctions-tweeter-rg"
   description = "Name of resource group"
 }
 
 variable "storageName" {
   type = string
   default = "trainingafstorage"
-  description = "Name of storage account"
 }
 
 # Function App
 
 variable "servicePlanName" {
   type = string
-  default = "functionServicePlan"
 }
 
 variable "appInsightsName" {
   type = string
-  default = "applicationInsights"
 }
 
 variable "functionAppName" {
   type = string
-  default = "twitterTrainingFunctionPW"
 }


### PR DESCRIPTION
## Intro

Yesterday I've learning how to create an Azure function that saves mocked tweets to queue. I've automated infrastructure by using terraform. It allows for setting up all the required Azure infrastructure with one command.

## What is done

Currently, the Terraform script creates and configures resources group, storage account, app service plan, function app, and application insights. The resources are connected together and parameterized with variables in `terraform.tfvars`.

##  Usage

**Prerequisites:** Azure CLI and Terraform installed.

To create infrastructure You must log in to the Azure CLI with `az login` and run `terraform apply` from the _infrastructure directory_.  
To destroy created infrastructure simply run `terraform destroy`

-------------

This branch can be safely removed after the merge 💣 